### PR TITLE
Fix logic error in OnlyShowLastVersion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/andybalholm/cascadia v1.1.0 // indirect
+	github.com/calmh/versions v1.0.1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v1.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/PuerkitoBio/goquery v1.5.0/go.mod h1:qD2PgZ9lccMbQlc7eEOjaeRlFQON7xY8
 github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/calmh/versions v1.0.1 h1:thI7mRSAPf26A+tjUjkIkDs62Fit7lY04YOeuy2k6/A=
+github.com/calmh/versions v1.0.1/go.mod h1:QLYDeR6z1lbfdydViIbnKUJ5jCLdDX4NV3fqBn7rTrk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/packages.go
+++ b/packages.go
@@ -102,10 +102,12 @@ func (p Packages) SearchByName(query string) Packages {
 func (p Packages) OnlyShowLastVersion() Packages {
 	output := Packages{}
 	for _, synoPkg := range p {
-		if pkgIndex, err := output.index(synoPkg.Name, synoPkg.Arch); err == nil && synoPkg.Version > output[pkgIndex].Version {
-			output[pkgIndex] = synoPkg
-		} else {
+		if pkgIndex, err := output.index(synoPkg.Name, synoPkg.Arch); err != nil {
+			// Not found
 			output = append(output, synoPkg)
+		} else if synoPkg.Version > output[pkgIndex].Version {
+			// Newer, overwrite
+			output[pkgIndex] = synoPkg
 		}
 	}
 	return output

--- a/packages.go
+++ b/packages.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/calmh/versions"
 	ini "gopkg.in/ini.v1"
 )
 
@@ -105,7 +106,7 @@ func (p Packages) OnlyShowLastVersion() Packages {
 		if pkgIndex, err := output.index(synoPkg.Name, synoPkg.Arch); err != nil {
 			// Not found
 			output = append(output, synoPkg)
-		} else if synoPkg.Version > output[pkgIndex].Version {
+		} else if versions.Compare(synoPkg.Version, output[pkgIndex].Version) > 0 {
 			// Newer, overwrite
 			output[pkgIndex] = synoPkg
 		}

--- a/packages_test.go
+++ b/packages_test.go
@@ -15,6 +15,7 @@ var pX8664,
 	pCedarview1,
 	pCedarview2,
 	pCedarview3,
+	pCedarview4,
 	pX86,
 	pEvansport,
 	pMulti,
@@ -56,7 +57,13 @@ func init() {
 		Name:        "cedarview-package",
 		DisplayName: "Cedarview Package 3",
 		Arch:        "cedarview",
-		Version:     "1.1",
+		Version:     "1.2",
+	}
+	pCedarview4 = &syno.Package{
+		Name:        "cedarview-package",
+		DisplayName: "Cedarview Package 3",
+		Arch:        "cedarview",
+		Version:     "1.10.banana-4",
 	}
 	pMulti = &syno.Package{
 		Name:        "multi-arch-package",
@@ -283,17 +290,21 @@ func TestFilterByName(t *testing.T) {
 }
 
 func TestOnlyShowLastVersion(t *testing.T) {
-	pp := syno.Packages{pCedarview2, pCedarview3}
+	pp := syno.Packages{pCedarview2, pCedarview3, pCedarview4}
 	ppf := pp.OnlyShowLastVersion()
 	if len(ppf) != 1 {
 		t.Errorf("Expected 1 packages to match but got %+v", ppf)
+	} else if ppf[0].Version != pCedarview4.Version {
+		t.Errorf("Expected version %s but got %s", pCedarview4.Version, ppf[0].Version)
 	}
 
 	// Also when they are in the reverse order
-	pp = syno.Packages{pCedarview3, pCedarview2}
+	pp = syno.Packages{pCedarview4, pCedarview3, pCedarview2}
 	ppf = pp.OnlyShowLastVersion()
 	if len(ppf) != 1 {
 		t.Errorf("Expected 1 packages to match but got %+v", ppf)
+	} else if ppf[0].Version != pCedarview4.Version {
+		t.Errorf("Expected version %s but got %s", pCedarview4.Version, ppf[0].Version)
 	}
 }
 

--- a/packages_test.go
+++ b/packages_test.go
@@ -281,9 +281,17 @@ func TestFilterByName(t *testing.T) {
 		t.Errorf("Expected 1 packages to match but got %+v", ppf)
 	}
 }
+
 func TestOnlyShowLastVersion(t *testing.T) {
 	pp := syno.Packages{pCedarview2, pCedarview3}
 	ppf := pp.OnlyShowLastVersion()
+	if len(ppf) != 1 {
+		t.Errorf("Expected 1 packages to match but got %+v", ppf)
+	}
+
+	// Also when they are in the reverse order
+	pp = syno.Packages{pCedarview3, pCedarview2}
+	ppf = pp.OnlyShowLastVersion()
 	if len(ppf) != 1 {
 		t.Errorf("Expected 1 packages to match but got %+v", ppf)
 	}


### PR DESCRIPTION
The "append" case would be taken if the versions were seen in descending
order, while the correct course of action would be to do nothing.

Fixes jdel/gosspks#9